### PR TITLE
chore: replace jozu-ai with kitops-ml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KitOps modules for Dagger
 
-A series of [Dagger](https://dagger.io/) modules for automating [KitOps ModelKit](https://github.com/jozu-ai/kitops) operations.
+A series of [Dagger](https://dagger.io/) modules for automating [KitOps ModelKit](https://github.com/kitops-ml/kitops) operations.
 
 Please file issues in [the main KitOps repository](https://github.com/kitops-ml/kitops).
 

--- a/kit/dagger/download_utils.go
+++ b/kit/dagger/download_utils.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	latestReleaseAPIURL = "https://api.github.com/repos/jozu-ai/kitops/releases/latest"
-	releaseAPIURL       = "https://api.github.com/repos/jozu-ai/kitops/releases/tags/%s"
+	latestReleaseAPIURL = "https://api.github.com/repos/kitops-ml/kitops/releases/latest"
+	releaseAPIURL       = "https://api.github.com/repos/kitops-ml/kitops/releases/tags/%s"
 )
 
 // Function to fetch the latest release information

--- a/tests/testdata/Kitfile
+++ b/tests/testdata/Kitfile
@@ -3,7 +3,7 @@ package:
   name: Test package
   version: 3.0.0
   description: This is a test ModelKit
-  authors: ['Jozu AI']
+  authors: ['The KitOps Authors']
 code:
   - path: README.md
     description: Readme file.


### PR DESCRIPTION
## Description
This PR updates all references of `jozu-ai` to `kitops-ml`
- this has no functional changes and purely a naming update for consistency

Thanks